### PR TITLE
Fix Remote Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ If the check should automatically pass if the submodule was not changed on this 
 
 This is optional, if included an unchanged submodule results in automatic pass. If set this option will be ignored if the event it a push. 
 
+### `fetch_depth`
+Fetch depth for the two relevant branches on a PR trigger. The action will checkout the two branches to this depth, if you know your branches are relatively short lived compared to the full history of your repo this can save you some processing time, network traffic, etc. by only checking out enough to cover your needs. 
+
+This is optional, if not included it will default to full history for the branches.
+
 ## Outputs
 ### `fails`
 The reason the action failed (if any). The check will stop at the first failure. 
@@ -36,8 +41,6 @@ jobs:
     steps:
     - name: Checkout this repo
       uses: actions/checkout@v2
-          with:
-              fetch-depth: 2
     - name: Checkout submodule repo
       uses: actions/checkout@v2
           with:
@@ -50,12 +53,14 @@ jobs:
       with:
         path: "path/to/submodule"
         branch: "master"
+        fetch_depth: "50"
+        pass_if_unchanged: "true"
 ```
 
 ### Usage Notes
 To ensure this action runs correctly you must checkout both the current repo and the submodule repo as expected with the appropriate amount of information about the repo history included. As shown above, the [Github Checkout Action](https://github.com/actions/checkout/) is a good way to set this up. Below are the main requirements for doing so:
 
-**Fetch Depth:** Your required fetch depth will vary based on use case. On the repo that this action is running on you will need a fetch depth of 2 for pushes or 1 (default) for Pull Requests unless you are using the pass if unchanged option, then you will require enough to view the history of both branches. On the submodule this will vary based on your workflow. You will need enough history for this action to determine the relationship between the submodule versions on the version being compared. If you are always working with very recent versions of the submodule this may be a small number, otherwise it could be much larger. 
+**Fetch Depth:** This action handles the fetching for the repo it is run on (checkout action does not have multibranch depth option at this time). On the submodule this will vary based on your workflow. You will need enough history for this action to determine the relationship between the submodule versions on the version being compared. If you are always working with very recent versions of the submodule this may be a small number, otherwise it could be much larger. 
 
 **Token:** If your submodule is private, provide a personal access token repo level access for the submodule so it can be checked out. 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is optional, if not included the submodule will only be checked for progres
 ### `pass_if_unchanged`
 If the check should automatically pass if the submodule was not changed on this branch. Only available on a PR, not a push. 
 
-This is optional, if included an unchanged submodule results in automatic pass. If set this option will be ignored if the event it a push. 
+This is optional, if included an unchanged submodule results in automatic pass. Will be ignored if the trigger event is not a pull request. 
 
 ### `fetch_depth`
 Fetch depth for the two relevant branches on a PR trigger. The action will checkout the two branches to this depth, if you know your branches are relatively short lived compared to the full history of your repo this can save you some processing time, network traffic, etc. by only checking out enough to cover your needs. 
@@ -49,7 +49,7 @@ jobs:
               token: ${{ secrets.PAT_for_Private_Submodule }}
               fetch-depth: 0
     - name: Check Submodule Name
-      uses: jtmullen/submodule-branch-check-action@v0.3.0-beta
+      uses: jtmullen/submodule-branch-check-action@v0.5.0-beta
       with:
         path: "path/to/submodule"
         branch: "master"
@@ -60,9 +60,9 @@ jobs:
 ### Usage Notes
 To ensure this action runs correctly you must checkout both the current repo and the submodule repo as expected with the appropriate amount of information about the repo history included. As shown above, the [Github Checkout Action](https://github.com/actions/checkout/) is a good way to set this up. Below are the main requirements for doing so:
 
-**Fetch Depth:** This action handles the fetching for the repo it is run on (checkout action does not have multibranch depth option at this time). On the submodule this will vary based on your workflow. You will need enough history for this action to determine the relationship between the submodule versions on the version being compared. If you are always working with very recent versions of the submodule this may be a small number, otherwise it could be much larger. 
+**Fetch Depth:** This action handles the fetching (not cloning!) for the repo it is run on (checkout action does not have multibranch depth option at this time). On the submodule this will vary based on your workflow. You will need enough history for this action to determine the relationship between the submodule versions on the version being compared. If you are always working with very recent versions of the submodule this may be a small number, otherwise it could be much larger. 
 
-**Token:** If your submodule is private, provide a personal access token repo level access for the submodule so it can be checked out. 
+**Token:** If your submodule is private, provide a personal access token repo level access for the submodule so it can be checked out. If not using actions/Checkout ensure your method also persists the token so this action can access the remote repo.  
 
 **Path:** Leave the repo the action is run on at the default location, checkout the submodule into its appropriate location in the repo. 
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: "If the check should always pass if the submodule hasn't been changed on a branch/commit"
     required: false
     default: ''
-  fetch-depth:
+  fetch_depth:
     description: "The fetch depth for both involved branches if run on a PR"
     required: false
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,11 @@ inputs:
     description: "If the check should always pass if the submodule hasn't been changed on a branch/commit"
     required: false
     default: ''
+  fetch-depth:
+    description: "The fetch depth for both involved branches if run on a PR"
+    required: false
+    default: ''
+    
 outputs:
   fails:
     description: "Cause of failure, if run failed"

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,6 @@ inputs:
     description: "The fetch depth for both involved branches if run on a PR"
     required: false
     default: ''
-    
 outputs:
   fails:
     description: "Cause of failure, if run failed"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,9 +29,11 @@ cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to 
 if [[ "${isPR}" = true ]]; then
 	echo "Checkout Branch Histories"
 	if [[ ! -z "${INPUT_FETCH_DEPTH}" ]]; then
+		echo "Histories to depth: ${INPUT_FETCH_DEPTH}"
 		git fetch origin "${TO_REF}" --depth "${INPUT_FETCH-DEPTH}"
 		git fetch origin "${FROM_REF}" --depth "${INPUT_FETCH-DEPTH}"
 	else
+		echo "Full Brach Histories"
 		git fetch origin "${TO_REF}"
 		git fetch origin "${FROM_REF}"
 	fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,11 +25,18 @@ fi
 
 cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to Github Workspace"
 
+## Fetch both branches for PR
+if [[ "${isPR}" = true ]]; then
+	echo "Checkout Branch Histories"
+	git fetch origin "${TO_REF}" --depth 100
+	git fetch origin "${FROM_REF}" --depth 100
+fi
+
 ## Check for submodule valid
 SUBMODULES=`git config --file .gitmodules --name-only --get-regexp path`
 echo "${SUBMODULES}" | grep ".${INPUT_PATH}." || error "Error: path is not a submodule"
 
-git checkout "origin/${TO_REF}"
+git checkout "${TO_REF}"
 git submodule init "${INPUT_PATH}"
 git submodule update "${INPUT_PATH}"
 
@@ -38,7 +45,7 @@ cd "${INPUT_PATH}" || error "${LINENO}__Error: Cannot change directory to the su
 SUBMODULE_HASH=`git rev-parse HEAD`
 
 cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to Github Workspace" 
-git checkout "origin/${FROM_REF}"
+git checkout "${FROM_REF}"
 
 git submodule update "${INPUT_PATH}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,10 +28,10 @@ cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to 
 ## Fetch both branches for PR
 if [[ "${isPR}" = true ]]; then
 	echo "Checkout Branch Histories"
-	if [[ ! -z "${INPUT_FETCH-DEPTH}" ]]; then
-		echo "Histories to depth: ${INPUT_FETCH-DEPTH}"
-		git fetch origin "${TO_REF}" --depth "${INPUT_FETCH-DEPTH}"
-		git fetch origin "${FROM_REF}" --depth "${INPUT_FETCH-DEPTH}"
+	if [[ ! -z "${INPUT_FETCH_DEPTH}" ]]; then
+		echo "Histories to depth: ${INPUT_FETCH_DEPTH}"
+		git fetch origin "${TO_REF}" --depth "${INPUT_FETCH_DEPTH}"
+		git fetch origin "${FROM_REF}" --depth "${INPUT_FETCH_DEPTH}"
 	else
 		echo "Full Brach Histories"
 		git fetch origin "${TO_REF}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,8 +28,8 @@ cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to 
 ## Fetch both branches for PR
 if [[ "${isPR}" = true ]]; then
 	echo "Checkout Branch Histories"
-	if [[ ! -z "${INPUT_FETCH_DEPTH}" ]]; then
-		echo "Histories to depth: ${INPUT_FETCH_DEPTH}"
+	if [[ ! -z "${INPUT_FETCH-DEPTH}" ]]; then
+		echo "Histories to depth: ${INPUT_FETCH-DEPTH}"
 		git fetch origin "${TO_REF}" --depth "${INPUT_FETCH-DEPTH}"
 		git fetch origin "${FROM_REF}" --depth "${INPUT_FETCH-DEPTH}"
 	else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to 
 SUBMODULES=`git config --file .gitmodules --name-only --get-regexp path`
 echo "${SUBMODULES}" | grep ".${INPUT_PATH}." || error "Error: path is not a submodule"
 
-git checkout "${TO_REF}"
+git checkout "origin/${TO_REF}"
 git submodule init "${INPUT_PATH}"
 git submodule update "${INPUT_PATH}"
 
@@ -38,7 +38,7 @@ cd "${INPUT_PATH}" || error "${LINENO}__Error: Cannot change directory to the su
 SUBMODULE_HASH=`git rev-parse HEAD`
 
 cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to Github Workspace" 
-git checkout "${FROM_REF}"
+git checkout "origin/${FROM_REF}"
 
 git submodule update "${INPUT_PATH}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,9 +28,13 @@ cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to 
 ## Fetch both branches for PR
 if [[ "${isPR}" = true ]]; then
 	echo "Checkout Branch Histories"
-	git fetch origin "${TO_REF}" --depth 100
-	echo "Checkout From Ref"
-	git fetch origin "${FROM_REF}" --depth 100
+	if [[ ! -z "${INPUT_FETCH_DEPTH}" ]]; then
+		git fetch origin "${TO_REF}" --depth "${INPUT_FETCH-DEPTH}"
+		git fetch origin "${FROM_REF}" --depth "${INPUT_FETCH-DEPTH}"
+	else
+		git fetch origin "${TO_REF}"
+		git fetch origin "${FROM_REF}"
+	fi
 fi
 
 ## Check for submodule valid

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,7 @@ cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to 
 if [[ "${isPR}" = true ]]; then
 	echo "Checkout Branch Histories"
 	git fetch origin "${TO_REF}" --depth 100
+	echo "Checkout From Ref"
 	git fetch origin "${FROM_REF}" --depth 100
 fi
 


### PR DESCRIPTION
The action now handles its own fetching for the repo it is being run on. Actions/Checkout doesn't quite have a set-up that is useful here to set-up the repo as is needed. 