### PR TITLE
Improve Checkout Safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
               token: ${{ secrets.PAT_for_Private_Submodule }}
               fetch-depth: 0
     - name: Check Submodule Name
-      uses: jtmullen/submodule-branch-check-action@v0.5.0-beta
+      uses: jtmullen/submodule-branch-check-action@v0.5.1-beta
       with:
         path: "path/to/submodule"
         branch: "master"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,40 +23,41 @@ else
 	error "Unknown Github Event Path"
 fi
 
-cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to Github Workspace"
+cd "${GITHUB_WORKSPACE}" || error "__Line:${LINENO}__Error: Cannot change directory to Github Workspace"
 
 ## Fetch both branches for PR
 if [[ "${isPR}" = true ]]; then
 	echo "Fetch Branch Histories"
 	if [[ ! -z "${INPUT_FETCH_DEPTH}" ]]; then
 		echo "Histories to depth: ${INPUT_FETCH_DEPTH}"
-		git fetch origin "${TO_REF}" --recurse-submodules=no --depth "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
-		git fetch origin "${FROM_REF}" --recurse-submodules=no --depth "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
+		git fetch origin "${TO_REF}" --recurse-submodules=no --depth "${INPUT_FETCH_DEPTH}" || error "__Line:${LINENO}__Error: Could not fetch history of ${TO_REF}"
+		git fetch origin "${FROM_REF}" --recurse-submodules=no --depth "${INPUT_FETCH_DEPTH}" || error "__Line:${LINENO}__Error: Could not fetch history of ${FROM_REF}"
 	else
 		echo "Full Brach Histories"
-		git fetch origin --recurse-submodules=no "${TO_REF}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
-		git fetch origin --recurse-submodules=no "${FROM_REF}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
+		git fetch origin --recurse-submodules=no "${TO_REF}" || error "__Line:${LINENO}__Error: Could not fetch history of ${TO_REF}"
+		git fetch origin --recurse-submodules=no "${FROM_REF}" || error "__Line:${LINENO}__Error: Could not fetch history of ${FROM_REF}"
 	fi
 fi
 
 ## Check for submodule valid
+echo "Submodule and Tree Info"
 SUBMODULES=`git config --file .gitmodules --name-only --get-regexp path`
 echo "${SUBMODULES}" | grep ".${INPUT_PATH}." || error "Error: path \"${INPUT_PATH}\" is not a submodule"
 
-git checkout "${TO_REF}" || error "${LINENO}__Error: Could not checkout ${TO_REF}"
-git submodule init "${INPUT_PATH}" || error "${LINENO}__Error: Could initialize submodule"
-git submodule update "${INPUT_PATH}" || error "${LINENO}__Error: Could not checkout submodule hash referenced by ${TO_REF} (is it pushed to remote?)"
+git checkout "${TO_REF}" || error "__Line:${LINENO}__Error: Could not checkout ${TO_REF}"
+git submodule init "${INPUT_PATH}" || error "__Line:${LINENO}__Error: Could initialize submodule"
+git submodule update "${INPUT_PATH}" || error "__Line:${LINENO}__Error: Could not checkout submodule hash referenced by ${TO_REF} (is it pushed to remote?)"
 
 echo "Switch to submodule at: ${INPUT_PATH}"
-cd "${INPUT_PATH}" || error "${LINENO}__Error: Cannot change directory to the submodule"
+cd "${INPUT_PATH}" || error "__Line:${LINENO}__Error: Cannot change directory to the submodule"
 SUBMODULE_HASH=`git rev-parse HEAD`
 
-cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to Github Workspace" 
-git checkout "${FROM_REF}"  || error "${LINENO}__Error: Could not checkout ${FROM_REF}"
+cd "${GITHUB_WORKSPACE}" || error "__Line:${LINENO}__Error: Cannot change directory to Github Workspace" 
+git checkout "${FROM_REF}"  || error "__Line:${LINENO}__Error: Could not checkout ${FROM_REF}"
 
-git submodule update "${INPUT_PATH}"  || error "${LINENO}__Error: Could not checkout submodule hash referenced by ${FROM_REF} (is it pushed to remote?)"
+git submodule update "${INPUT_PATH}"  || error "__Line:${LINENO}__Error: Could not checkout submodule hash referenced by ${FROM_REF} (is it pushed to remote?)"
 
-cd "${INPUT_PATH}" || error "${LINENO}__Error: Cannot change directory to the submodule"
+cd "${INPUT_PATH}" || error "__Line:${LINENO}__Error: Cannot change directory to the submodule"
 SUBMODULE_HASH_BASE=`git rev-parse HEAD`
 
 echo "Submodule ${INPUT_PATH} Changed from: ${SUBMODULE_HASH_BASE} to ${SUBMODULE_HASH}"
@@ -73,7 +74,7 @@ pass () {
 	exit 0	
 }
 
-cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to Github Workspace" 
+cd "${GITHUB_WORKSPACE}" || error "__Line:${LINENO}__Error: Cannot change directory to Github Workspace" 
 
 ## Pass if they are unchanged
 if [[ ! -z "${INPUT_PASS_IF_UNCHANGED}" ]]; then
@@ -89,7 +90,7 @@ if [[ ! -z "${INPUT_PASS_IF_UNCHANGED}" ]]; then
 	fi	
 fi
 
-cd "${INPUT_PATH}" || error "${LINENO}__Error: Cannot change directory to the submodule"
+cd "${INPUT_PATH}" || error "__Line:${LINENO}__Error: Cannot change directory to the submodule"
 
 ## Check if on required branch
 if [[ ! -z "${INPUT_BRANCH}" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,12 +30,12 @@ if [[ "${isPR}" = true ]]; then
 	echo "Checkout Branch Histories"
 	if [[ ! -z "${INPUT_FETCH_DEPTH}" ]]; then
 		echo "Histories to depth: ${INPUT_FETCH_DEPTH}"
-		git fetch origin "${TO_REF}" --depth "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
-		git fetch origin "${FROM_REF}" --depth "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
+		git fetch origin "${TO_REF}" --depth --recurse-submodules=no "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
+		git fetch origin "${FROM_REF}" --depth --recurse-submodules=no "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
 	else
 		echo "Full Brach Histories"
-		git fetch origin "${TO_REF}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
-		git fetch origin "${FROM_REF}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
+		git fetch origin --recurse-submodules=no "${TO_REF}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
+		git fetch origin --recurse-submodules=no "${FROM_REF}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
 	fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,11 +27,11 @@ cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to 
 
 ## Fetch both branches for PR
 if [[ "${isPR}" = true ]]; then
-	echo "Checkout Branch Histories"
+	echo "Fetch Branch Histories"
 	if [[ ! -z "${INPUT_FETCH_DEPTH}" ]]; then
 		echo "Histories to depth: ${INPUT_FETCH_DEPTH}"
-		git fetch origin "${TO_REF}" --depth --recurse-submodules=no "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
-		git fetch origin "${FROM_REF}" --depth --recurse-submodules=no "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
+		git fetch origin "${TO_REF}" --recurse-submodules=no --depth "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
+		git fetch origin "${FROM_REF}" --recurse-submodules=no --depth "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
 	else
 		echo "Full Brach Histories"
 		git fetch origin --recurse-submodules=no "${TO_REF}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,31 +30,31 @@ if [[ "${isPR}" = true ]]; then
 	echo "Checkout Branch Histories"
 	if [[ ! -z "${INPUT_FETCH_DEPTH}" ]]; then
 		echo "Histories to depth: ${INPUT_FETCH_DEPTH}"
-		git fetch origin "${TO_REF}" --depth "${INPUT_FETCH_DEPTH}"
-		git fetch origin "${FROM_REF}" --depth "${INPUT_FETCH_DEPTH}"
+		git fetch origin "${TO_REF}" --depth "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
+		git fetch origin "${FROM_REF}" --depth "${INPUT_FETCH_DEPTH}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
 	else
 		echo "Full Brach Histories"
-		git fetch origin "${TO_REF}"
-		git fetch origin "${FROM_REF}"
+		git fetch origin "${TO_REF}" || error "${LINENO}__Error: Could not fetch history of ${TO_REF}"
+		git fetch origin "${FROM_REF}" || error "${LINENO}__Error: Could not fetch history of ${FROM_REF}"
 	fi
 fi
 
 ## Check for submodule valid
 SUBMODULES=`git config --file .gitmodules --name-only --get-regexp path`
-echo "${SUBMODULES}" | grep ".${INPUT_PATH}." || error "Error: path is not a submodule"
+echo "${SUBMODULES}" | grep ".${INPUT_PATH}." || error "Error: path \"${INPUT_PATH}\" is not a submodule"
 
-git checkout "${TO_REF}"
-git submodule init "${INPUT_PATH}"
-git submodule update "${INPUT_PATH}"
+git checkout "${TO_REF}" || error "${LINENO}__Error: Could not checkout ${TO_REF}"
+git submodule init "${INPUT_PATH}" || error "${LINENO}__Error: Could initialize submodule"
+git submodule update "${INPUT_PATH}" || error "${LINENO}__Error: Could not checkout submodule hash referenced by ${TO_REF} (is it pushed to remote?)"
 
 echo "Switch to submodule at: ${INPUT_PATH}"
 cd "${INPUT_PATH}" || error "${LINENO}__Error: Cannot change directory to the submodule"
 SUBMODULE_HASH=`git rev-parse HEAD`
 
 cd "${GITHUB_WORKSPACE}" || error "${LINENO}__Error: Cannot change directory to Github Workspace" 
-git checkout "${FROM_REF}"
+git checkout "${FROM_REF}"  || error "${LINENO}__Error: Could not checkout ${FROM_REF}"
 
-git submodule update "${INPUT_PATH}"
+git submodule update "${INPUT_PATH}"  || error "${LINENO}__Error: Could not checkout submodule hash referenced by ${FROM_REF} (is it pushed to remote?)"
 
 cd "${INPUT_PATH}" || error "${LINENO}__Error: Cannot change directory to the submodule"
 SUBMODULE_HASH_BASE=`git rev-parse HEAD`


### PR DESCRIPTION
Add error handling around checkouts (both parent repo and submodule) and submodule init. 

This fixes #7 as git submodule update will attempt to checkout nonexistent hash and therefore result in an error