### PR TITLE
Handle New Submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ jobs:
       uses: actions/checkout@v2
     - name: Checkout submodule repo
       uses: actions/checkout@v2
-          with:
-              repository: UserOrOrganization/Repo
-              path: "path/to/repo"
-              token: ${{ secrets.PAT_for_Private_Submodule }}
-              fetch-depth: 0
+      with:
+        repository: UserOrOrganization/Repo
+        path: "path/to/repo"
+        token: ${{ secrets.PAT_for_Private_Submodule }}
+        fetch-depth: 0
     - name: Check Submodule Name
       uses: jtmullen/submodule-branch-check-action@v0-beta
       with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,7 +90,7 @@ fail () {
 }
 
 pass () {
-	echo -e "\032[0;31mPASS: $1\033[0m"
+	echo -e "\033[0;32mPASS: $1\033[0m"
 	echo "::set-output name=fails::"
 	exit 0	
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,7 +90,7 @@ fail () {
 }
 
 pass () {
-	echo "PASS: $1"
+	echo -e "\032[0;31mPASS: $1\033[0m"
 	echo "::set-output name=fails::"
 	exit 0	
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,7 @@ newSubmodule=false
 
 newSubmoduleWarning() {
 	newSubmodule=true
-	echo "::warning::Submodule $1 does not exist on the base branch $2"
-	echo "Cannot do progression check for new submodules"
+	echo "::warning::Submodule $1 does not exist on the base branch $2 \n Cannot do progression check for new submodules on this run"
 }
 
 REPO=`jq -r ".repository.full_name" "${GITHUB_EVENT_PATH}"`


### PR DESCRIPTION
Currently new submodules result in an error because we cannot check out the submodule on the base (obviously). 

Now we give a warning and do the checks we can (branch) and skip the rest (progression)