### PR TITLE
Fix Submodule Checkout Depth Branches

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,7 +97,11 @@ if [[ ! -z "${INPUT_SUB_FETCH_DEPTH}" ]]; then
 	git fetch origin --recurse-submodules=no --depth "${INPUT_SUB_FETCH_DEPTH}" || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
 else 
 	echo "Full Submodule History"
-	git fetch origin --recurse-submodules=no --unshallow || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
+	if [[ "$(git rev-parse --is-shallow-repository)" = true ]]; then
+		git fetch origin --recurse-submodules=no || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
+	else
+		git fetch origin --recurse-submodules=no --unshallow || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
+	fi
 fi
 
 cd "${GITHUB_WORKSPACE}" || error "__Line:${LINENO}__Error: Cannot change directory to Github Workspace" 


### PR DESCRIPTION
Minor change to ensure we are getting the history for all remote branches of the submodule (so we can figure out relationships). v1.0.0 would fail to have enough info for some situations and error instead of failing with a useful message. 