### PR TITLE
Fix Submodule Fetch Depth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,6 @@ jobs:
       with:
         path: "submodule-action-test-submodule"
         event_path: "action/test/pr_pass_all.json"
-        require_head: true
         branch: "main"
     - name: Verify Pass All PR
       run: test -z "${{ steps.pass-all.outputs.fails }}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,13 +91,13 @@ SUBMODULE_HASH=`git rev-parse HEAD`
 ## Update Submodule 
 if [[ ! -z "${INPUT_SUB_FETCH_DEPTH}" ]]; then
 	echo "Submodule History to depth: ${INPUT_SUB_FETCH_DEPTH}"
-	git fetch origin --recurse-submodules=no --depth "${INPUT_SUB_FETCH_DEPTH}" || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
+	git fetch --recurse-submodules=no --depth "${INPUT_SUB_FETCH_DEPTH}" || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
 else 
 	echo "Full Submodule History"
 	if [[ "$(git rev-parse --is-shallow-repository)" = true ]]; then
-		git fetch origin --recurse-submodules=no || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
+		git fetch --recurse-submodules=no || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
 	else
-		git fetch origin --recurse-submodules=no --unshallow || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
+		git fetch --recurse-submodules=no --unshallow || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
 	fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,9 +95,9 @@ if [[ ! -z "${INPUT_SUB_FETCH_DEPTH}" ]]; then
 else 
 	echo "Full Submodule History"
 	if [[ "$(git rev-parse --is-shallow-repository)" = true ]]; then
-		git fetch --recurse-submodules=no || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
-	else
 		git fetch --recurse-submodules=no --unshallow || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
+	else
+		git fetch --recurse-submodules=no || error "__Line:${LINENO}__Error: Error Fetching Submodule ${INPUT_PATH}"
 	fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,9 +88,6 @@ git submodule update --init --depth=1 "${INPUT_PATH}" || error "__Line:${LINENO}
 cd "${INPUT_PATH}" || error "__Line:${LINENO}__Error: Cannot change directory to the submodule"
 SUBMODULE_HASH=`git rev-parse HEAD`
 
-## Need to get all remote branches, we don't know what we don't know about the submodule
-git remote set-branches origin '*' || error "__Line:${LINENO}__Error: Could not set branches"
-
 ## Update Submodule 
 if [[ ! -z "${INPUT_SUB_FETCH_DEPTH}" ]]; then
 	echo "Submodule History to depth: ${INPUT_SUB_FETCH_DEPTH}"


### PR DESCRIPTION
set-branches was causing git to not actually get the histories needed in some cases. Removing this line seems to fix it, this line seems to be left over from old logic and unneeded now. 

Also tweaked test for better coverage of progression checking. 