### PR TITLE
Install LFS in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.11
 
 RUN apk add --no-cache bash
 RUN apk --no-cache add git
+RUN apk --no-cache add git-lfs
 RUN apk --no-cache add jq
+
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
I had trouble trying to use this action on a repo which uses Git LFS as this wasn't installed in the Docker image.  The error show was that it couldn't checkout `FROM_HASH`.  This PR installs Git LFS on the Docker image, solving the problem.