### PR TITLE
Add param to check first-parent ancestry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The path to the submodule, this is required. Do not include leading or trailing 
 ### `branch` (optional)
 The name of a branch that the submodule hash must be on (after the push or on the head PR branch)
 
+### `first_parent` (optional)
+Require the submodule's checked-out commit to be an ancestor of the specified branch strictly along the path following first parents only.  That is, the submodule's current HEAD must either currently be or have at some point in the past been the tip of the branch specified.
+
 ### `pass_if_unchanged` (optional)
 For pull request only, if this is included the check will automatically pass if none of the commits modify the submodule. 
 
@@ -52,6 +55,7 @@ jobs:
       with:
         path: "path/to/submodule"
         branch: "main"
+        first_parent: true
         fetch_depth: "50"
         pass_if_unchanged: true
         require_head: true

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "Which branch the submodule must be on"
     required: false
     default: ''
+  first_parent:
+    description: "Require submodule commit to be an ancestor of specified branch strictly along first-parent path"
+    required: false
+    default: ''
   pass_if_unchanged:
     description: "If the check should always pass if the submodule hasn't been changed on a branch/commit"
     required: false
@@ -32,6 +36,7 @@ inputs:
     description: "Override the path to the github event json file. Used for testing."
     required: false
     default: ''
+  
 outputs:
   fails:
     description: "Cause of failure, if run failed"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -176,6 +176,14 @@ if [[ ! -z "${INPUT_BRANCH}" ]]; then
 	echo "${BRANCHES}" | grep "/${INPUT_BRANCH}$" || fail "Submodule ${INPUT_PATH} Hash ${SUBMODULE_HASH} is not on branch ${INPUT_BRANCH}"
 	echo "Submodule is on branch ${INPUT_BRANCH}"
 	echo "::endgroup::"
+
+	if [[ ! -z "${INPUT_FIRST_PARENT}" ]]; then
+		echo "::group::Check First-Parent Ancestry"
+		git rev-list --first-parent ${INPUT_BRANCH} --not ${SUBMODULE_HASH}^@ | grep "${SUBMODULE_HASH}" || fail "Commit ${SUBMODULE_HASH} is not a first-parent ancestor of the tip of ${INPUT_BRANCH}"
+		echo "Commit ${SUBMODULE_HASH} is a first-parent ancestor of the tip of ${INPUT_BRANCH}"
+		echo "::endgroup::"
+	fi
+
 fi
 
 


### PR DESCRIPTION
This PR adds an input parameter with which the user can specify that they wish the submodule to be on the required branch by first-parent ancestry specifically.  

Motivation: We want submodules to always be on master when updating them in the main repo's master branch.  Without this feature, we couldn't prevent the following sequence of events:
* create submodule PR pointing at master
* create main repo PR pointing at master, checking out submodule's feature branch (for review/testing)
* make changes to submodule and merge submodule PR
* merge main repo PR, forgetting to checkout submodule master first
– submodule's HEAD is now merged into master, but is missing commits from later on in the feature branch.