### PR TITLE
Restore Repo State at End of Run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
       with:
         repository:  jtmullen/submodule-action-test-parent
         fetch-depth: 0
+        ref: '66fe441ec6c2db7565686f303dde85d7eb8ad132'
     - name: Checkout Action
       uses: actions/checkout@v2
       with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,11 @@
 startrev=`git rev-parse HEAD`
 
 restoreState () {
-	echo "Restoring Repo State"
+	echo "::group::Restoring Repo State"
 	cd "${GITHUB_WORKSPACE}"
 	git checkout $startrev
 	git submodule update
+	echo "::endgroup::"
 }
 
 error () {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ startrev=`git rev-parse HEAD`
 
 restoreState () {
 	echo "Restoring Repo State"
+	cd "${GITHUB_WORKSPACE}"
 	git checkout $startrev
 	git submodule update
 }


### PR DESCRIPTION
Restore the repo state at the end of run so that the repo is in the correct state for any subsequent steps in a workflow. 

Closes #21 